### PR TITLE
Add RDS instance to backend dev env

### DIFF
--- a/ops/terraform/dev/backend/variables.tf
+++ b/ops/terraform/dev/backend/variables.tf
@@ -3,6 +3,11 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "db_password" {
+  description = "Password for the backend app RDS instance"
+}
+
 variable "service_version" {
+  description = "Service version/docker image tag to deploy"
   default = "latest"
 }


### PR DESCRIPTION
For #36.

Adds a postgres RDS instance to the `dev` backend configs. Folks should be able to grab the host, user, password and db name using the scripts in the `ops/config` directory. Try: `cd ops/config && ./fetch.sh dev`.